### PR TITLE
Add extra parameter to allow preventing this step from reporting in Port

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ In addition, as cookiecutter is an Open Source project you can make your own pro
 | portRunId             | Port run ID to came from triggering the action                                                                                | Yes      |           |
 | monorepoUrl           | If using scaffolding within a monorepo specify the URL here                                                                   | Yes      |           |
 | scaffoldDirectory     | Root folder to scaffold when using monorepo                                                                                   | Yes      |           |
+| createPortEntity      | Whether should create port entity with the action or not. You can set this to `false` if you'd like to create the entry yourself with `port-labs/port-github-action`  | No  | true  |
 
 ## Quickstart - Scaffold Golang Template
 

--- a/action.yaml
+++ b/action.yaml
@@ -39,6 +39,10 @@ inputs:
   templateDirectory:
     description: 'The directory to scaffold the cookiecutter template from'
     required: false
+  createPortEntity:
+    description: 'Whether to create a Port entity for the repository'
+    required: false
+    default: "true"
 runs:
   using: docker
   image: Dockerfile

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,7 @@ template_directory="$INPUT_TEMPLATEDIRECTORY"
 port_user_inputs="$INPUT_PORTUSERINPUTS"
 monorepo_url="$INPUT_MONOREPOURL"
 scaffold_directory="$INPUT_SCAFFOLDDIRECTORY"
+create_port_entity="$INPUT_CREATEPORTENTITY"
 branch_name="port_$port_run_id"
 
 get_access_token() {
@@ -172,7 +173,10 @@ main() {
 
   send_log "Reporting to Port the new entity created 🚢"
 
-  report_to_port
+  if [[ "$create_port_entity" == "true" ]]
+  then
+    report_to_port
+  fi
 
   if [ -n "$monorepo_url" ] && [ -n "$scaffold_directory" ]; then
     send_log "Finished! 🏁✅"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -171,11 +171,12 @@ main() {
 
   url="https://github.com/$org_name/$repository_name"
 
-  send_log "Reporting to Port the new entity created 🚢"
-
   if [[ "$create_port_entity" == "true" ]]
   then
+    send_log "Reporting to Port the new entity created 🚢"
     report_to_port
+  else
+    send_log "Skipping reporting to Port the new entity created 🚢"
   fi
 
   if [ -n "$monorepo_url" ] && [ -n "$scaffold_directory" ]; then


### PR DESCRIPTION
In general, this step does not report in Port the way we need to, so we prefer it to not report at all, and use https://github.com/port-labs/port-github-action to create related entities afterwords.